### PR TITLE
Criando gateway e lambda authorizer

### DIFF
--- a/handlers/src/main/java/br/com/fiap/authorizer/AuthPolicyBuilder.java
+++ b/handlers/src/main/java/br/com/fiap/authorizer/AuthPolicyBuilder.java
@@ -1,0 +1,36 @@
+package br.com.fiap.authorizer;
+
+import com.amazonaws.services.lambda.runtime.events.IamPolicyResponse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class AuthPolicyBuilder {
+
+    public static IamPolicyResponse allow(String principalId, String resource) {
+        List<IamPolicyResponse.Statement> statementList = new ArrayList<>();
+        statementList.add(IamPolicyResponse.allowStatement(resource));
+
+        return IamPolicyResponse.builder()
+                .withPrincipalId(principalId)
+                .withPolicyDocument(buildPolicyDocument(statementList))
+                .build();
+    }
+
+    public static IamPolicyResponse deny(String resource) {
+        List<IamPolicyResponse.Statement> statementList = new ArrayList<>();
+        statementList.add(IamPolicyResponse.denyStatement(resource));
+
+        return IamPolicyResponse.builder()
+                .withPrincipalId("user")
+                .withPolicyDocument(buildPolicyDocument(statementList))
+                .build();
+    }
+
+    private static IamPolicyResponse.PolicyDocument buildPolicyDocument(List<IamPolicyResponse.Statement> statementList) {
+        return IamPolicyResponse.PolicyDocument.builder()
+                .withVersion(IamPolicyResponse.VERSION_2012_10_17)
+                .withStatement(statementList)
+                .build();
+    }
+}

--- a/handlers/src/main/java/br/com/fiap/authorizer/AuthorizerHandler.java
+++ b/handlers/src/main/java/br/com/fiap/authorizer/AuthorizerHandler.java
@@ -1,0 +1,47 @@
+package br.com.fiap.authorizer;
+
+import br.com.fiap.util.LogUtils;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayCustomAuthorizerEvent;
+import com.amazonaws.services.lambda.runtime.events.IamPolicyResponse;
+
+import java.util.Base64;
+
+public class AuthorizerHandler implements RequestHandler<APIGatewayCustomAuthorizerEvent, IamPolicyResponse> {
+
+    @Override
+    public IamPolicyResponse handleRequest(final APIGatewayCustomAuthorizerEvent apiGatewayCustomAuthorizerEvent, final Context context) {
+        final String invokedFunctionArn = apiGatewayCustomAuthorizerEvent.getMethodArn();
+
+        try {
+            String token = apiGatewayCustomAuthorizerEvent.getAuthorizationToken().trim();
+            if (token.isEmpty()) throw new RuntimeException("Token não informado");
+
+            String principalId = getPrincipalId(token);
+
+            return AuthPolicyBuilder.allow(principalId, invokedFunctionArn);
+        } catch (Exception exception) {
+            LogUtils.logException(exception);
+            return AuthPolicyBuilder.deny(invokedFunctionArn);
+        }
+    }
+
+    private static String getPrincipalId(String token) {
+        if (!token.startsWith("Basic ")) throw new RuntimeException("Tipo de autenticação não suportado");
+
+        String base64 = token.replace("Basic ", "");
+        String decoded = new String(Base64.getDecoder().decode(base64));
+
+        String[] tokenParts = decoded.split(":");
+        if (tokenParts.length != 2) throw new RuntimeException("Token em formato inválido");
+
+        String username = tokenParts[0];
+        String password = tokenParts[1];
+
+        // TODO: Buscar no banco de dados
+        String principalId = "1";
+
+        return principalId;
+    }
+}

--- a/handlers/src/main/java/br/com/fiap/util/LogUtils.java
+++ b/handlers/src/main/java/br/com/fiap/util/LogUtils.java
@@ -1,0 +1,25 @@
+package br.com.fiap.util;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+public class LogUtils {
+
+    public static void logException(Exception exception) {
+        try {
+            StringWriter stringWriter = new StringWriter();
+            PrintWriter printWriter = new PrintWriter(stringWriter);
+            exception.printStackTrace(printWriter);
+
+            String stackTrace = stringWriter.toString();
+            System.out.println(stackTrace);
+
+            stringWriter.close();
+            printWriter.close();
+        } catch (IOException ioException) {
+            System.out.println("Falha ao logar exceção: " + ioException.getMessage());
+            ioException.printStackTrace();
+        }
+    }
+}

--- a/template.yaml
+++ b/template.yaml
@@ -9,6 +9,9 @@ Globals:
     MemorySize: 512
 
 Resources:
+  ApiGateway:
+    Type: AWS::Serverless::HttpApi
+
   ListPunchesFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -20,10 +23,12 @@ Resources:
       MemorySize: 512
       Events:
         ListPunches:
-          Type: Api
+          Type: HttpApi
           Properties:
+            ApiId: !Ref ApiGateway
             Path: /punches
             Method: get
+
   RegisterPunchesFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -46,7 +46,7 @@ Resources:
           Type: HttpApi
           Properties:
             ApiId: !Ref ApiGateway
-            Path: /punches
+            Path: /punch
             Method: get
 
   RegisterPunchesFunction:

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,26 @@ Globals:
 Resources:
   ApiGateway:
     Type: AWS::Serverless::HttpApi
+    Properties:
+      Auth:
+        DefaultAuthorizer: LoginAuthorizer
+        Authorizers:
+          LoginAuthorizer:
+            FunctionArn: !GetAtt AuthorizerFunction.Arn
+            AuthorizerPayloadFormatVersion: "1.0"
+            Identity:
+              Headers:
+                - Authorization
+
+  AuthorizerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: handlers
+      Handler: br.com.fiap.authorizer.AuthorizerHandler::handleRequest
+      Runtime: java17
+      Architectures:
+        - x86_64
+      MemorySize: 128
 
   ListPunchesFunction:
     Type: AWS::Serverless::Function

--- a/template.yaml
+++ b/template.yaml
@@ -60,7 +60,7 @@ Resources:
       MemorySize: 512
       Events:
         RegisterPunch:
-          Type: Api
+          Type: HttpApi
           Properties:
             Path: /punch
             Method: post


### PR DESCRIPTION
Depende do #1 

Criei uma API HTTP simples que interceptará todas as rotas e as direcionará para um Lambda Authorizer. O autorizador espera receber as credenciais no formato `Basic [base 64 de usuario:senha]`.

Aproveitei para criar um utilitário para logar os stacktraces de forma mais clara

No próximo PR irei fazê-lo buscar os dados direto do banco.